### PR TITLE
fix typo

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -35,7 +35,7 @@ inquirer
 
     const destinationPath = path.join(
       workflowsPath,
-      'nextjs_bundle_analysis.yml'
+      'nuxtjs_bundle_analysis.yml'
     );
     fs.copyFileSync(templatePath, destinationPath);
   });


### PR DESCRIPTION
fixes: https://github.com/wattanx/nuxt-bundle-analysis/issues/1

## Description
The file generated by `npx -p nuxt-bundle-analysis generate` was `nextjs_bundle_analysis.yml`.
The correct file is `nuxtjs_bundle_analysis.yml`.

## ⛳️ Current behavior (updates)
 `npx -p nuxt-bundle-analysis generate` -> generated `nextjs_bundle_analysis.yml`

## 🚀 New behavior
 `npx -p nuxt-bundle-analysis generate` -> generated `nuxtjs_bundle_analysis.yml`

## 💣 Is this a breaking change (Yes/No):
No