### PR TITLE
feat: support vite

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -2,6 +2,7 @@ import { defineBuildConfig } from 'unbuild';
 
 export default defineBuildConfig({
   entries: [
+    'src/vite/report.ts',
     'src/compare.ts',
     'src/generate.ts',
     'src/report.ts',

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "test": "pnpm build && pnpm build:playground && pnpm dev:prepare && pnpm report && pnpm compare && vitest run",
     "test:update": "pnpm build && pnpm build:playground && pnpm dev:prepare && pnpm report && pnpm compare && vitest -u",
+    "test:vite": "NUXT_BUNDLE_ANALYSIS_BUILDER=\"vite\" pnpm run test",
     "minor": "npm version minor",
     "build": "unbuild",
     "build:playground": "pnpm --filter playground build",
@@ -44,8 +45,10 @@
     "@discoveryjs/json-ext": "^0.6.1",
     "destr": "^2.0.3",
     "filesize": "^8.0.7",
+    "globby": "^14.0.2",
     "inquirer": "^8.2.4",
     "mkdirp": "^1.0.4",
+    "pathe": "^1.1.2",
     "pkg-types": "^1.1.3"
   },
   "devDependencies": {

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,10 +1,14 @@
 import { defineNuxtConfig } from 'nuxt/config';
 
+const builder = (process.env.NUXT_BUNDLE_ANALYSIS_BUILDER || 'webpack') as
+  | 'webpack'
+  | 'vite';
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   ssr: false,
   telemetry: false,
-  builder: 'webpack',
+  builder: builder,
   webpack: {
     analyze: {
       generateStatsFile: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,12 +17,18 @@ importers:
       filesize:
         specifier: ^8.0.7
         version: 8.0.7
+      globby:
+        specifier: ^14.0.2
+        version: 14.0.2
       inquirer:
         specifier: ^8.2.4
         version: 8.2.5
       mkdirp:
         specifier: ^1.0.4
         version: 1.0.4
+      pathe:
+        specifier: ^1.1.2
+        version: 1.1.2
       pkg-types:
         specifier: ^1.1.3
         version: 1.1.3
@@ -1148,6 +1154,10 @@ packages:
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
+  '@sindresorhus/merge-streams@2.3.0':
+    resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
+    engines: {node: '>=18'}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -2315,6 +2325,10 @@ packages:
     resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  globby@14.0.2:
+    resolution: {integrity: sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==}
+    engines: {node: '>=18'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -3074,8 +3088,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  pathe@1.1.1:
-    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
+  path-type@5.0.0:
+    resolution: {integrity: sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==}
+    engines: {node: '>=12'}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -3776,6 +3791,10 @@ packages:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
 
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
   smob@1.4.1:
     resolution: {integrity: sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ==}
 
@@ -4040,6 +4059,10 @@ packages:
 
   unhead@1.7.4:
     resolution: {integrity: sha512-oOv+9aQS85DQUd0f1uJBtb2uG3SKwCURSTuUWp9WKKzANCb1TjW2dWp5TFmJH5ILF6urXi4uUQfjK+SawzBJAA==}
+
+  unicorn-magic@0.1.0:
+    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
 
   unimport@3.4.0:
     resolution: {integrity: sha512-M/lfFEgufIT156QAr/jWHLUn55kEmxBBiQsMxvRSIbquwmeJEyQYgshHDEvQDWlSJrVOOTAgnJ3FvlsrpGkanA==}
@@ -5056,7 +5079,7 @@ snapshots:
       jiti: 1.20.0
       knitwork: 1.0.0
       mlly: 1.4.2
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.1.3
       scule: 1.0.0
       semver: 7.5.4
@@ -5080,7 +5103,7 @@ snapshots:
       jiti: 1.20.0
       knitwork: 1.0.0
       mlly: 1.4.2
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.1.3
       scule: 1.0.0
       semver: 7.5.4
@@ -5097,7 +5120,7 @@ snapshots:
       '@nuxt/ui-templates': 1.3.1
       defu: 6.1.2
       hookable: 5.5.3
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.1.3
       postcss-import-resolver: 2.0.0
       std-env: 3.4.3
@@ -5114,7 +5137,7 @@ snapshots:
       consola: 3.2.3
       defu: 6.1.2
       hookable: 5.5.3
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.1.3
       postcss-import-resolver: 2.0.0
       std-env: 3.4.3
@@ -5144,7 +5167,7 @@ snapshots:
       node-fetch: 3.3.2
       ofetch: 1.3.3
       parse-git-config: 3.0.0
-      pathe: 1.1.1
+      pathe: 1.1.2
       rc9: 2.1.1
       std-env: 3.4.3
     transitivePeerDependencies:
@@ -5175,7 +5198,7 @@ snapshots:
       magic-string: 0.30.3
       mlly: 1.4.2
       ohash: 1.1.3
-      pathe: 1.1.1
+      pathe: 1.1.2
       perfect-debounce: 1.0.0
       pkg-types: 1.1.3
       postcss: 8.4.30
@@ -5233,7 +5256,7 @@ snapshots:
       mini-css-extract-plugin: 2.7.6(webpack@5.88.2)
       mlly: 1.4.2
       ohash: 1.1.3
-      pathe: 1.1.1
+      pathe: 1.1.2
       pify: 6.1.0
       postcss: 8.4.30
       postcss-import: 15.1.0(postcss@8.4.30)
@@ -5463,6 +5486,8 @@ snapshots:
     optional: true
 
   '@sinclair/typebox@0.27.8': {}
+
+  '@sindresorhus/merge-streams@2.3.0': {}
 
   '@trysound/sax@0.2.0': {}
 
@@ -5900,7 +5925,7 @@ snapshots:
     dependencies:
       '@babel/parser': 7.23.0
       '@rollup/pluginutils': 5.0.4(rollup@3.29.3)
-      pathe: 1.1.1
+      pathe: 1.1.2
     transitivePeerDependencies:
       - rollup
 
@@ -6010,7 +6035,7 @@ snapshots:
       jiti: 1.20.0
       mlly: 1.4.2
       ohash: 1.1.3
-      pathe: 1.1.1
+      pathe: 1.1.2
       perfect-debounce: 1.0.0
       pkg-types: 1.1.3
       rc9: 2.1.1
@@ -6650,7 +6675,7 @@ snapshots:
     dependencies:
       enhanced-resolve: 5.15.0
       mlly: 1.4.2
-      pathe: 1.1.1
+      pathe: 1.1.2
       ufo: 1.3.0
 
   fast-deep-equal@3.1.3: {}
@@ -6800,7 +6825,7 @@ snapshots:
       https-proxy-agent: 5.0.1
       mri: 1.2.0
       node-fetch-native: 1.4.0
-      pathe: 1.1.1
+      pathe: 1.1.2
       tar: 6.2.0
     transitivePeerDependencies:
       - supports-color
@@ -6848,6 +6873,15 @@ snapshots:
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
+
+  globby@14.0.2:
+    dependencies:
+      '@sindresorhus/merge-streams': 2.3.0
+      fast-glob: 3.3.2
+      ignore: 5.2.4
+      path-type: 5.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.1.0
 
   graceful-fs@4.2.11: {}
 
@@ -7150,7 +7184,7 @@ snapshots:
       jiti: 1.20.0
       mlly: 1.4.2
       node-forge: 1.3.1
-      pathe: 1.1.1
+      pathe: 1.1.2
       std-env: 3.4.3
       ufo: 1.3.0
       untun: 0.1.2
@@ -7341,7 +7375,7 @@ snapshots:
   mlly@1.4.2:
     dependencies:
       acorn: 8.10.0
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.1.3
       ufo: 1.3.0
 
@@ -7419,7 +7453,7 @@ snapshots:
       ofetch: 1.3.3
       ohash: 1.1.3
       openapi-typescript: 6.7.0
-      pathe: 1.1.1
+      pathe: 1.1.2
       perfect-debounce: 1.0.0
       pkg-types: 1.1.3
       pretty-bytes: 6.1.1
@@ -7545,7 +7579,7 @@ snapshots:
       nypm: 0.3.3
       ofetch: 1.3.3
       ohash: 1.1.3
-      pathe: 1.1.1
+      pathe: 1.1.2
       perfect-debounce: 1.0.0
       pkg-types: 1.1.3
       prompts: 2.4.2
@@ -7603,7 +7637,7 @@ snapshots:
     dependencies:
       citty: 0.1.4
       execa: 8.0.1
-      pathe: 1.1.1
+      pathe: 1.1.2
       ufo: 1.3.0
 
   object-assign@4.1.1: {}
@@ -7699,7 +7733,7 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  pathe@1.1.1: {}
+  path-type@5.0.0: {}
 
   pathe@1.1.2: {}
 
@@ -8419,6 +8453,8 @@ snapshots:
 
   slash@4.0.0: {}
 
+  slash@5.1.0: {}
+
   smob@1.4.1: {}
 
   source-list-map@2.0.1: {}
@@ -8669,7 +8705,7 @@ snapshots:
       defu: 6.1.2
       mime: 3.0.0
       node-fetch-native: 1.4.0
-      pathe: 1.1.1
+      pathe: 1.1.2
 
   unhead@1.7.4:
     dependencies:
@@ -8677,6 +8713,8 @@ snapshots:
       '@unhead/schema': 1.7.4
       '@unhead/shared': 1.7.4
       hookable: 5.5.3
+
+  unicorn-magic@0.1.0: {}
 
   unimport@3.4.0(rollup@3.29.3):
     dependencies:
@@ -8686,7 +8724,7 @@ snapshots:
       local-pkg: 0.4.3
       magic-string: 0.30.3
       mlly: 1.4.2
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.1.3
       scule: 1.0.0
       strip-literal: 1.3.0
@@ -8707,7 +8745,7 @@ snapshots:
       json5: 2.2.3
       local-pkg: 0.4.3
       mlly: 1.4.2
-      pathe: 1.1.1
+      pathe: 1.1.2
       scule: 1.0.0
       unplugin: 1.5.0
       yaml: 2.3.2
@@ -8744,7 +8782,7 @@ snapshots:
     dependencies:
       citty: 0.1.4
       consola: 3.2.3
-      pathe: 1.1.1
+      pathe: 1.1.2
 
   untyped@1.4.0:
     dependencies:
@@ -8794,7 +8832,7 @@ snapshots:
       cac: 6.7.14
       debug: 4.3.4
       mlly: 1.4.2
-      pathe: 1.1.1
+      pathe: 1.1.2
       picocolors: 1.0.0
       vite: 4.4.9(@types/node@18.18.0)(terser@5.20.0)
     transitivePeerDependencies:

--- a/src/report.ts
+++ b/src/report.ts
@@ -7,10 +7,12 @@ import { parseChunked } from '@discoveryjs/json-ext';
 import { StatsType } from './types';
 import {
   getBuildOutputDirectory,
+  getBuilder,
   getClientDir,
   getOptions,
   getStatsFilePath,
 } from './utils';
+import { getClientStats } from './vite/report';
 
 const memoryCache: { [scriptPath: string]: number } = {};
 
@@ -48,6 +50,18 @@ async function generateAnalysisJson() {
       `"${buildOutputDir} is not found" - you may not have your working directory set correctly, or not have run "nuxt build".`
     );
     process.exit(1);
+  }
+
+  if (getBuilder(options) === 'vite') {
+    const rawData = JSON.stringify(await getClientStats());
+    try {
+      fs.mkdirSync(path.join(buildOutputDir, 'analyze/'));
+    } catch (err) {}
+    fs.writeFileSync(
+      path.join(buildOutputDir, 'analyze/__bundle_analysis.json'),
+      rawData
+    );
+    return;
   }
 
   const allPageSizes = Object.entries(statsFile.namedChunkGroups).map(

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,10 @@ export type NuxtBundleAnalysisOptions = {
   clientDir: string;
   statsFile: string;
   minimumChangeThreshold: number;
+  /**
+   * @default 'webpack'
+   */
+  builder?: 'webpack' | 'vite';
 };
 
 export type BundleAnalysisType = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,3 +38,9 @@ export const getMinimumChangeThreshold = (
 ): number => {
   return options.minimumChangeThreshold || 0;
 };
+
+export const getBuilder = (options: NuxtBundleAnalysisOptions) => {
+  return (
+    options.builder || process.env.NUXT_BUNDLE_ANALYSIS_BUILDER || 'webpack'
+  );
+};

--- a/src/vite/report.ts
+++ b/src/vite/report.ts
@@ -1,0 +1,27 @@
+import fsp from 'node:fs/promises';
+import { globby } from 'globby';
+import { join } from 'pathe';
+
+export async function getClientStats() {
+  const rootDir = process.cwd();
+  const stats = await analyzeSizes('**/*.js', join(rootDir, '.output/public'));
+
+  return [stats];
+}
+
+async function analyzeSizes(pattern: string | string[], rootDir: string) {
+  const files: string[] = await globby(pattern, { cwd: rootDir });
+  let totalBytes = 0;
+  for (const file of files) {
+    const path = join(rootDir, file);
+    const isSymlink = (
+      await fsp.lstat(path).catch(() => null)
+    )?.isSymbolicLink();
+
+    if (!isSymlink) {
+      const bytes = Buffer.byteLength(await fsp.readFile(path));
+      totalBytes += bytes;
+    }
+  }
+  return { path: 'app', size: totalBytes };
+}

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -12,6 +12,18 @@ exports[`ts test > Snapshot of comparison results 1`] = `
 | \`pages/test\` | removed |"
 `;
 
+exports[`ts test > Vite comparison results test 1`] = `
+"
+<!-- __NUXTJS_BUNDLE -->
+# Bundle Size
+| Route | Size (gzipped) |
+| --- | --- |
+| \`app\` | 155.61 kB (🔴 55.61 kB) |
+| \`pages/index\` | removed |
+| \`components/tutorial\` | removed |
+| \`pages/test\` | removed |"
+`;
+
 exports[`ts test > comparison results test 1`] = `
 "
 <!-- __NUXTJS_BUNDLE -->

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,11 @@
 import fs from 'fs';
 
+const isVite = process.env.NUXT_BUNDLE_ANALYSIS_BUILDER === 'vite';
+console.log(
+  'process.env.NUXT_BUNDLE_ANALYSIS_BUILDER',
+  process.env.NUXT_BUNDLE_ANALYSIS_BUILDER
+);
+
 describe('ts test', () => {
   it('generated __bundle_analysis.json', async () => {
     expect(
@@ -13,7 +19,7 @@ describe('ts test', () => {
     ).toBeTruthy();
   });
 
-  it('comparison results test', () => {
+  it.skipIf(isVite)('comparison results test', () => {
     const contents = fs
       .readFileSync('playground/.nuxt/analyze/__bundle_analysis_comment.txt')
       .toString();
@@ -36,7 +42,15 @@ describe('ts test', () => {
     expect(contents).toMatchSnapshot();
   });
 
-  it('Snapshot of comparison results', () => {
+  it.skipIf(isVite)('Snapshot of comparison results', () => {
+    const contents = fs
+      .readFileSync('playground/.nuxt/analyze/__bundle_analysis_comment.txt')
+      .toString();
+
+    expect(contents).toMatchSnapshot();
+  });
+
+  it.skipIf(!isVite)('Vite comparison results test', () => {
     const contents = fs
       .readFileSync('playground/.nuxt/analyze/__bundle_analysis_comment.txt')
       .toString();


### PR DESCRIPTION
Fixes: https://github.com/wattanx/nuxt-bundle-analysis/issues/18

## Description

This PR also supports `builder: 'vite'`.

Only the total bundle size is supported as we could not figure out how to analyse it per page in the Vite bundle.